### PR TITLE
Precompile to ES5 rather than Node 6 ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
   "homepage": "https://github.com/badavis/strict-password-generator#readme",
   "devDependencies": {
     "babel": "^6.5.2",
-    "babel-cli": "^6.11.4",
-    "babel-preset-es6-node6": "^0.5.0"
+    "babel-cli": "^6.11.4"
   },
   "babel": {
     "presets": [
-      "es6-node6"
+      "es2015"
     ]
   },
   "dependencies": {
+    "babel-preset-es2015": "^6.14.0",
     "chai": "^3.5.0",
     "debug": "^2.2.0",
     "lodash": "^4.15.0",


### PR DESCRIPTION
To provide support for browsers and pre-Node6 environments, changes the precompile target to ES5.
